### PR TITLE
Widgets: info button fetch data from API

### DIFF
--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -1,0 +1,19 @@
+import ReactMarkdown, { Options } from "react-markdown";
+
+export const Markdown = ({ children, ...props }: Options) => {
+  return (
+    <ReactMarkdown
+      className="prose"
+      components={{
+        a: ({ children, href }) => (
+          <a href={href} target="_blank" rel="noreferrer">
+            {children}
+          </a>
+        ),
+      }}
+      {...props}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+};

--- a/src/containers/atlas/widgets/efgs/extent/index.tsx
+++ b/src/containers/atlas/widgets/efgs/extent/index.tsx
@@ -6,7 +6,6 @@ import { getEFGSortedFromEFGCode } from "@/lib/taxonomy";
 
 import { useApiEcosystemsEcosystemIdWidgetsWidgetIdGet } from "@/types/generated/ecosystems";
 
-import { Info } from "@/containers/atlas/info";
 import { ByCountryExtent } from "@/containers/atlas/widgets/efgs/extent/by-country";
 import { GlobExtent } from "@/containers/atlas/widgets/efgs/extent/glob";
 import {
@@ -14,6 +13,7 @@ import {
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -31,7 +31,7 @@ export const WidgetEcosystemsExtent = () => {
     <Widget>
       <WidgetHeader>
         <WidgetTitle>Global Ecosystem group extent</WidgetTitle>
-        <Info>Hello</Info>
+        <WidgetInfo id="extent_efgs" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader isLoading={isFetching && !isFetched}>

--- a/src/containers/atlas/widgets/efgs/protected_efgs/index.tsx
+++ b/src/containers/atlas/widgets/efgs/protected_efgs/index.tsx
@@ -8,12 +8,12 @@ import { cn, formatPercentage } from "@/lib/utils";
 
 import { useApiEcosystemsEcosystemIdWidgetsWidgetIdGet } from "@/types/generated/ecosystems";
 
-import { Info } from "@/containers/atlas/info";
 import {
   Widget,
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -37,7 +37,7 @@ export const WidgetEcosystemsProtectedEfgs = () => {
     <Widget>
       <WidgetHeader>
         <WidgetTitle>Protection level</WidgetTitle>
-        <Info>Hello</Info>
+        <WidgetInfo id="protected_efgs" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader isLoading={isFetching && !isFetched}>

--- a/src/containers/atlas/widgets/item.tsx
+++ b/src/containers/atlas/widgets/item.tsx
@@ -2,8 +2,6 @@
 
 import { PropsWithChildren } from "react";
 
-import Markdown from "react-markdown";
-
 import Image from "next/image";
 
 import { cn } from "@/lib/utils";
@@ -13,6 +11,7 @@ import { useApiWidgetsGet } from "@/types/generated/widgets";
 import { Info } from "@/containers/atlas/info";
 
 import { H3 } from "@/components/ui/h3";
+import { Markdown } from "@/components/ui/markdown";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export const Widget = ({ children, className }: PropsWithChildren<{ className?: string }>) => {

--- a/src/containers/atlas/widgets/item.tsx
+++ b/src/containers/atlas/widgets/item.tsx
@@ -2,10 +2,17 @@
 
 import { PropsWithChildren } from "react";
 
+import Markdown from "react-markdown";
+
 import Image from "next/image";
 
 import { cn } from "@/lib/utils";
 
+import { useApiWidgetsGet } from "@/types/generated/widgets";
+
+import { Info } from "@/containers/atlas/info";
+
+import { H3 } from "@/components/ui/h3";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export const Widget = ({ children, className }: PropsWithChildren<{ className?: string }>) => {
@@ -71,5 +78,26 @@ export const WidgetNoData = ({ children, isNoData }: PropsWithChildren<{ isNoDat
         </p>
       </div>
     </div>
+  );
+};
+
+export const WidgetInfo = ({ id }: { id: string }) => {
+  const { data: widgetsData } = useApiWidgetsGet();
+
+  const WIDGET = widgetsData?.data?.find((widget) => widget.id === id);
+  if (!WIDGET) return null;
+
+  const { metadata } = WIDGET;
+  if (!metadata || !metadata.length) return null;
+
+  const markdown = metadata[0].abstract;
+
+  if (!markdown) return null;
+
+  return (
+    <Info>
+      <H3>{WIDGET.name}</H3>
+      <Markdown className="prose">{markdown}</Markdown>
+    </Info>
   );
 };

--- a/src/containers/atlas/widgets/location/country_contribution/index.tsx
+++ b/src/containers/atlas/widgets/location/country_contribution/index.tsx
@@ -4,12 +4,12 @@ import { useApiLocationsLocationWidgetsWidgetIdGet } from "@/types/generated/loc
 
 import { useSyncLocation } from "@/app/(atlas)/atlas/store";
 
-import { Info } from "@/containers/atlas/info";
 import {
   Widget,
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -29,7 +29,7 @@ export const WidgetLocationCountryContribution = () => {
     <Widget>
       <WidgetHeader>
         <WidgetTitle>Contribution status</WidgetTitle>
-        <Info>Hello</Info>
+        <WidgetInfo id="country_con_stat" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader isLoading={isFetching && !isFetched}>

--- a/src/containers/atlas/widgets/location/current_status/index.tsx
+++ b/src/containers/atlas/widgets/location/current_status/index.tsx
@@ -5,12 +5,12 @@ import { useApiLocationsLocationWidgetsWidgetIdGet } from "@/types/generated/loc
 
 import { useSyncLocation } from "@/app/(atlas)/atlas/store";
 
-import { Info } from "@/containers/atlas/info";
 import {
   Widget,
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -38,7 +38,7 @@ export const WidgetLocationStatus = () => {
     <Widget>
       <WidgetHeader>
         <WidgetTitle>Current status</WidgetTitle>
-        <Info>Hello</Info>
+        <WidgetInfo id="current_status" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader isLoading={isFetching && !isFetched}>

--- a/src/containers/atlas/widgets/location/ecosystem_assesment/index.tsx
+++ b/src/containers/atlas/widgets/location/ecosystem_assesment/index.tsx
@@ -11,12 +11,12 @@ import { useApiLocationsLocationWidgetsWidgetIdGet } from "@/types/generated/loc
 
 import { useSyncLocation } from "@/app/(atlas)/atlas/store";
 
-import { Info } from "@/containers/atlas/info";
 import {
   Widget,
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -74,12 +74,7 @@ export const WidgetLocationEcosystemAssesment = () => {
         <WidgetTitle>
           Ecosystems Risk status <span className="font-medium normal-case">(Type level)</span>
         </WidgetTitle>
-        <Info>
-          This widget shows the proportion of national ecosystem types assessed under each risk
-          category in the Red List of Ecosystems. Ecosystem types are sub-units within the ecosystem
-          functional groups displayed on the Atlas, and represent the level at which risk status is
-          assessed. More information on https://www.iucnrle.org/
-        </Info>
+        <WidgetInfo id="ecosystem_assesment" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader isLoading={isFetching && !isFetched}>

--- a/src/containers/atlas/widgets/location/extent/index.tsx
+++ b/src/containers/atlas/widgets/location/extent/index.tsx
@@ -4,12 +4,12 @@ import { useApiLocationsLocationWidgetsWidgetIdGet } from "@/types/generated/loc
 
 import { useSyncLocation } from "@/app/(atlas)/atlas/store";
 
-import { Info } from "@/containers/atlas/info";
 import {
   Widget,
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -39,7 +39,7 @@ export const WidgetLocationExtent = () => {
     <Widget>
       <WidgetHeader>
         <WidgetTitle>Extent</WidgetTitle>
-        <Info>Hello</Info>
+        <WidgetInfo id="extent_efgs" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader

--- a/src/containers/atlas/widgets/location/extent_realms/index.tsx
+++ b/src/containers/atlas/widgets/location/extent_realms/index.tsx
@@ -11,12 +11,12 @@ import { useApiLocationsLocationWidgetsWidgetIdGet } from "@/types/generated/loc
 
 import { useSyncLocation } from "@/app/(atlas)/atlas/store";
 
-import { Info } from "@/containers/atlas/info";
 import {
   Widget,
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -70,7 +70,7 @@ export const WidgetLocationExtentRealms = () => {
     <Widget>
       <WidgetHeader>
         <WidgetTitle>Realms</WidgetTitle>
-        <Info>Hello</Info>
+        <WidgetInfo id="extent_realms" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader isLoading={isFetching && !isFetched}>

--- a/src/containers/atlas/widgets/location/protected_efgs/index.tsx
+++ b/src/containers/atlas/widgets/location/protected_efgs/index.tsx
@@ -10,12 +10,12 @@ import { useApiLocationsLocationWidgetsWidgetIdGet } from "@/types/generated/loc
 
 import { useSyncLocation } from "@/app/(atlas)/atlas/store";
 
-import { Info } from "@/containers/atlas/info";
 import {
   Widget,
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -72,7 +72,7 @@ export const WidgetLocationProtectedEfgs = () => {
     <Widget>
       <WidgetHeader>
         <WidgetTitle>Top 5 protected ecosystem groups</WidgetTitle>
-        <Info>Hello</Info>
+        <WidgetInfo id="protected_efgs" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader isLoading={isFetching && !isFetched}>

--- a/src/containers/atlas/widgets/location/realms_break/index.tsx
+++ b/src/containers/atlas/widgets/location/realms_break/index.tsx
@@ -13,12 +13,12 @@ import { useApiLocationsLocationWidgetsWidgetIdGet } from "@/types/generated/loc
 
 import { useSyncLocation } from "@/app/(atlas)/atlas/store";
 
-import { Info } from "@/containers/atlas/info";
 import {
   Widget,
   WidgetContent,
   WidgetError,
   WidgetHeader,
+  WidgetInfo,
   WidgetLoader,
   WidgetNoData,
   WidgetTitle,
@@ -65,7 +65,7 @@ export const WidgetLocationRealmsBreak = () => {
     <Widget>
       <WidgetHeader>
         <WidgetTitle>Realms breakdown</WidgetTitle>
-        <Info>Hello</Info>
+        <WidgetInfo id="realms_break" />
       </WidgetHeader>
       <WidgetContent>
         <WidgetLoader isLoading={isFetching && !isFetched}>

--- a/src/containers/data/how-to/use-the-data.tsx
+++ b/src/containers/data/how-to/use-the-data.tsx
@@ -1,7 +1,6 @@
-import Markdown from "react-markdown";
-
 import { Grid } from "@/components/ui/grid";
 import { H3 } from "@/components/ui/h3";
+import { Markdown } from "@/components/ui/markdown";
 import { Section } from "@/components/ui/section";
 import {
   Table,

--- a/src/containers/data/question-and-answers/index.tsx
+++ b/src/containers/data/question-and-answers/index.tsx
@@ -2,14 +2,13 @@
 
 import { useState } from "react";
 
-import Markdown from "react-markdown";
-
 import { FiChevronDown, FiChevronUp } from "react-icons/fi";
 
 import { FAQS } from "@/lib/faqs";
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Grid } from "@/components/ui/grid";
+import { Markdown } from "@/components/ui/markdown";
 import { Section } from "@/components/ui/section";
 
 const FaqItem = ({ question, answer }: { question: string; answer: string }) => {

--- a/src/containers/data/sources-catalogue/table/expanded.tsx
+++ b/src/containers/data/sources-catalogue/table/expanded.tsx
@@ -1,9 +1,8 @@
-import Markdown from "react-markdown";
-
 import { Row } from "@tanstack/react-table";
 
 import { Dataset } from "@/types/dataset";
 
+import { Markdown } from "@/components/ui/markdown";
 import { TableBody, TableCell, TableHead, TableRow } from "@/components/ui/table";
 
 export const Expanded = (row: Row<Dataset>) => {


### PR DESCRIPTION
This pull request introduces a new `Markdown` component and replaces the `Info` component with `WidgetInfo` across various files. Additionally, it updates imports to use the new `Markdown` component.

### Introduction of `Markdown` Component:
* [`src/components/ui/markdown.tsx`](diffhunk://#diff-1ba072e8b626f6d89b1c47d702e1f6cba9a5d004364d2a305fa817d62f379e01R1-R19): Added a new `Markdown` component that uses `ReactMarkdown` to render markdown content with custom link handling.

### Replacement of `Info` with `WidgetInfo`:
* [`src/containers/atlas/widgets/efgs/extent/index.tsx`](diffhunk://#diff-ca058ee791c4629efd372130fe8c272a109bf53bcb6fa723cc12b356116e8598L9-R16): Replaced `Info` with `WidgetInfo` for the `WidgetEcosystemsExtent` component. [[1]](diffhunk://#diff-ca058ee791c4629efd372130fe8c272a109bf53bcb6fa723cc12b356116e8598L9-R16) [[2]](diffhunk://#diff-ca058ee791c4629efd372130fe8c272a109bf53bcb6fa723cc12b356116e8598L34-R34)
* [`src/containers/atlas/widgets/efgs/protected_efgs/index.tsx`](diffhunk://#diff-aed9cae2d86cdc5cdf5d23af279dc2256c9feb656380a419325393ef866a16c6L11-R16): Replaced `Info` with `WidgetInfo` for the `WidgetEcosystemsProtectedEfgs` component. [[1]](diffhunk://#diff-aed9cae2d86cdc5cdf5d23af279dc2256c9feb656380a419325393ef866a16c6L11-R16) [[2]](diffhunk://#diff-aed9cae2d86cdc5cdf5d23af279dc2256c9feb656380a419325393ef866a16c6L40-R40)
* [`src/containers/atlas/widgets/location/country_contribution/index.tsx`](diffhunk://#diff-f22302a30b19dc51bf74ddc6722507234a6dbbbc7c4ce0777f7959f0b7c18a11L7-R12): Replaced `Info` with `WidgetInfo` for the `WidgetLocationCountryContribution` component. [[1]](diffhunk://#diff-f22302a30b19dc51bf74ddc6722507234a6dbbbc7c4ce0777f7959f0b7c18a11L7-R12) [[2]](diffhunk://#diff-f22302a30b19dc51bf74ddc6722507234a6dbbbc7c4ce0777f7959f0b7c18a11L32-R32)
* [`src/containers/atlas/widgets/location/current_status/index.tsx`](diffhunk://#diff-3b146d0450ef2045c78776a4cac4ccd9d8122d20585f9fb8ad90b805d2bc473aL8-R13): Replaced `Info` with `WidgetInfo` for the `WidgetLocationStatus` component. [[1]](diffhunk://#diff-3b146d0450ef2045c78776a4cac4ccd9d8122d20585f9fb8ad90b805d2bc473aL8-R13) [[2]](diffhunk://#diff-3b146d0450ef2045c78776a4cac4ccd9d8122d20585f9fb8ad90b805d2bc473aL41-R41)
* [`src/containers/atlas/widgets/location/ecosystem_assesment/index.tsx`](diffhunk://#diff-90f559ac9e838005dbd22b2e0e26902864cc1d2da6fe908a0bf5d12daf52e62cL14-R19): Replaced `Info` with `WidgetInfo` for the `WidgetLocationEcosystemAssesment` component. [[1]](diffhunk://#diff-90f559ac9e838005dbd22b2e0e26902864cc1d2da6fe908a0bf5d12daf52e62cL14-R19) [[2]](diffhunk://#diff-90f559ac9e838005dbd22b2e0e26902864cc1d2da6fe908a0bf5d12daf52e62cL77-R77)
* [`src/containers/atlas/widgets/location/extent/index.tsx`](diffhunk://#diff-3b5852c9ac02a619da623d1871aba2ebe1f8df09249af7409dc5ffe2a87f4a59L7-R12): Replaced `Info` with `WidgetInfo` for the `WidgetLocationExtent` component. [[1]](diffhunk://#diff-3b5852c9ac02a619da623d1871aba2ebe1f8df09249af7409dc5ffe2a87f4a59L7-R12) [[2]](diffhunk://#diff-3b5852c9ac02a619da623d1871aba2ebe1f8df09249af7409dc5ffe2a87f4a59L42-R42)
* [`src/containers/atlas/widgets/location/extent_realms/index.tsx`](diffhunk://#diff-e69ab64977365e33b793175298942b1bdbd7e04e76792ded61039ef21bfe418cL14-R19): Replaced `Info` with `WidgetInfo` for the `WidgetLocationExtentRealms` component. [[1]](diffhunk://#diff-e69ab64977365e33b793175298942b1bdbd7e04e76792ded61039ef21bfe418cL14-R19) [[2]](diffhunk://#diff-e69ab64977365e33b793175298942b1bdbd7e04e76792ded61039ef21bfe418cL73-R73)
* [`src/containers/atlas/widgets/location/protected_efgs/index.tsx`](diffhunk://#diff-adef33179662d2ad12ca363d378fdbd3f590513936e0b4baf766fc4cef2ddc11L13-R18): Replaced `Info` with `WidgetInfo` for the `WidgetLocationProtectedEfgs` component. [[1]](diffhunk://#diff-adef33179662d2ad12ca363d378fdbd3f590513936e0b4baf766fc4cef2ddc11L13-R18) [[2]](diffhunk://#diff-adef33179662d2ad12ca363d378fdbd3f590513936e0b4baf766fc4cef2ddc11L75-R75)
* [`src/containers/atlas/widgets/location/realms_break/index.tsx`](diffhunk://#diff-db38d29f2a9a638cb3d52f3f9655ad8cc8717ef15906ae419c778bc6cbe0f3fcL16-R21): Replaced `Info` with `WidgetInfo` for the `WidgetLocationRealmsBreak` component. [[1]](diffhunk://#diff-db38d29f2a9a638cb3d52f3f9655ad8cc8717ef15906ae419c778bc6cbe0f3fcL16-R21) [[2]](diffhunk://#diff-db38d29f2a9a638cb3d52f3f9655ad8cc8717ef15906ae419c778bc6cbe0f3fcL68-R68)

### Updates to Imports:
* [`src/containers/data/how-to/use-the-data.tsx`](diffhunk://#diff-dd43011687668d1e1bacf11f85e7356d87f24a7025bff2853c294906dacec37fL1-R3): Updated import to use the new `Markdown` component.
* [`src/containers/data/question-and-answers/index.tsx`](diffhunk://#diff-b0e3cc12a5368fb4eedb0a6273c1a148ecbbac59a48acdc85d2ff96f1372fe2aL5-R11): Updated import to use the new `Markdown` component.
* [`src/containers/data/sources-catalogue/table/expanded.tsx`](diffhunk://#diff-74a1781a4c8de267fb6c89e118673146d51f1464607ff25c8051da5bb4f467e3L1-R5): Updated import to use the new `Markdown` component.