### PR TITLE
Atlas mobile sidebar

### DIFF
--- a/src/app/(atlas)/atlas/store.ts
+++ b/src/app/(atlas)/atlas/store.ts
@@ -126,7 +126,7 @@ export const popupAtom = atom<LngLat | null>(null);
 export const tourAtom = atom<boolean>();
 
 // mobile
+export const atlasMobileStateAtom = atom<"hero" | "map">("hero");
 export const atlasMobileSidebarAtom = atom<boolean>(false);
 
 // export const atlasPopupAtom = atom<boolean>(false);
-// export const mobileStateAtom = atom<"hero" | "map" | "sidebar">("map");

--- a/src/app/(atlas)/atlas/store.ts
+++ b/src/app/(atlas)/atlas/store.ts
@@ -126,4 +126,7 @@ export const popupAtom = atom<LngLat | null>(null);
 export const tourAtom = atom<boolean>();
 
 // mobile
-export const mobileStateAtom = atom<"hero" | "map" | "sidebar">("map");
+export const atlasMobileSidebarAtom = atom<boolean>(false);
+
+// export const atlasPopupAtom = atom<boolean>(false);
+// export const mobileStateAtom = atom<"hero" | "map" | "sidebar">("map");

--- a/src/components/map/controls/data/index.tsx
+++ b/src/components/map/controls/data/index.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { FC, HTMLAttributes, PropsWithChildren } from "react";
+
+import { TooltipPortal } from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+import { CollapseSidebarIcon } from "@/components/ui/icons/collapse-sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+import { CONTROL_BUTTON_STYLES } from "../constants";
+
+interface DataControlProps {
+  id?: string;
+  className?: HTMLAttributes<HTMLDivElement>["className"];
+  onClick?: () => void;
+}
+
+export const DataControl: FC<PropsWithChildren<DataControlProps>> = ({
+  id,
+  className,
+  onClick,
+}: PropsWithChildren<DataControlProps>) => {
+  return (
+    <div className={cn("flex flex-col space-y-0.5", className)}>
+      {/* <Popover> */}
+      <Tooltip>
+        {/* <PopoverTrigger asChild> */}
+        <TooltipTrigger asChild>
+          <button
+            id={id}
+            className={cn({
+              [CONTROL_BUTTON_STYLES.default]: true,
+              [CONTROL_BUTTON_STYLES.hover]: true,
+              [CONTROL_BUTTON_STYLES.active]: true,
+            })}
+            aria-label="Map settings"
+            type="button"
+            onClick={onClick}
+          >
+            <CollapseSidebarIcon className="relative h-full w-full" />
+          </button>
+        </TooltipTrigger>
+        {/* </PopoverTrigger> */}
+
+        <TooltipPortal>
+          <TooltipContent side="left" align="center">
+            <div className="text-xxs">Data</div>
+          </TooltipContent>
+        </TooltipPortal>
+
+        {/* <PopoverContent side="left" align="start">
+          {children}
+          <PopoverArrow className="fill-white" width={10} height={5} />
+        </PopoverContent> */}
+      </Tooltip>
+      {/* </Popover> */}
+    </div>
+  );
+};
+
+export default DataControl;

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import * as React from "react";
+
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-0 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  },
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {
+  close?: boolean;
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", close, className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+      {children}
+      {close && (
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      )}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/src/containers/atlas/hero.tsx
+++ b/src/containers/atlas/hero.tsx
@@ -1,17 +1,11 @@
 import Link from "next/link";
 
-import { useSetAtom } from "jotai";
-
-import { mobileStateAtom } from "@/app/(atlas)/atlas/store";
-
 import { Button } from "@/components/ui/button";
 import { Grid } from "@/components/ui/grid";
 import { H2 } from "@/components/ui/h2";
 import { Section } from "@/components/ui/section";
 
 export const AtlasHero = () => {
-  const setMobileState = useSetAtom(mobileStateAtom);
-
   return (
     <Section hero className="min-h-0">
       <div className="container">
@@ -42,7 +36,7 @@ export const AtlasHero = () => {
                 size="lg"
                 variant="default"
                 className="w-full"
-                onClick={() => setMobileState("map")}
+                // onClick={() => setMobileState("map")}
               >
                 See Atlas
               </Button>

--- a/src/containers/atlas/hero.tsx
+++ b/src/containers/atlas/hero.tsx
@@ -1,25 +1,33 @@
 import Link from "next/link";
 
+import { useSetAtom } from "jotai";
+
+import { atlasMobileStateAtom } from "@/app/(atlas)/atlas/store";
+
 import { Button } from "@/components/ui/button";
 import { Grid } from "@/components/ui/grid";
-import { H2 } from "@/components/ui/h2";
+import { H3 } from "@/components/ui/h3";
 import { Section } from "@/components/ui/section";
 
 export const AtlasHero = () => {
+  const setAtlasMobileState = useSetAtom(atlasMobileStateAtom);
+
   return (
     <Section hero className="min-h-0">
       <div className="container">
         <Grid className="lg:gap-y-9">
           <div className="col-span-12 lg:col-span-10 lg:col-start-2 2xl:col-span-8 2xl:col-start-3">
-            <H2>Atlas Unveiling: Desktop Experience First</H2>
+            <H3 className="text-center">
+              Atlas Unveiling: <br /> Desktop Experience First
+            </H3>
           </div>
           <div className="col-span-12 space-y-10 lg:col-span-8 lg:col-start-3">
             <div className="space-y-2">
-              <p className="text-xl lg:text-2xl">
-                This initial release of the Atlas is best viewed on desktop for an optimal
-                experience due to its complexity and size.
+              <p className="text-center">
+                This initial release of the Atlas is best viewed on a larger screen for an optimal
+                experience.
               </p>
-              <p className="text-xl lg:text-2xl">
+              {/* <p className="text-center">
                 While we are actively working to enhance mobile support, you can get an exclusive
                 preview by watching{" "}
                 <Link
@@ -29,21 +37,23 @@ export const AtlasHero = () => {
                   this video demonstration
                 </Link>
                 .
-              </p>
+              </p> */}
             </div>
             <div className="col-span-12 space-y-2">
               <Button
-                size="lg"
                 variant="default"
                 className="w-full"
-                // onClick={() => setMobileState("map")}
+                onClick={() => setAtlasMobileState("map")}
               >
-                See Atlas
+                I understand, take me to the Atlas
               </Button>
 
-              <Link href="/" className="block w-full sm:w-auto">
-                <Button size="lg" variant="outline" className="w-full">
-                  See Homepage
+              <Link
+                href="/resources/#global-ecosystem-atlas-screencast"
+                className="block w-full sm:w-auto"
+              >
+                <Button variant="outline" className="w-full">
+                  Watch the Atlas demonstration
                 </Button>
               </Link>
             </div>

--- a/src/containers/atlas/layout.tsx
+++ b/src/containers/atlas/layout.tsx
@@ -4,53 +4,37 @@ import { PropsWithChildren, Suspense } from "react";
 import { LayoutGroup } from "framer-motion";
 import { useAtom } from "jotai";
 
-import { mobileStateAtom } from "@/app/(atlas)/atlas/store";
+import { atlasMobileSidebarAtom } from "@/app/(atlas)/atlas/store";
 
-import { AtlasHero } from "@/containers/atlas/hero";
 import { AtlasMap } from "@/containers/atlas/map";
 import { AtlasNav } from "@/containers/atlas/nav";
 import { AtlasSidebar } from "@/containers/atlas/sidebar";
 import { AtlasTour } from "@/containers/atlas/tour";
-import { Footer } from "@/containers/footer";
 import { Header } from "@/containers/header";
 import { Media } from "@/containers/media";
-import { Newsletter } from "@/containers/newsletter";
+
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 
 export const AtlasLayoutMobile = ({ children }: PropsWithChildren) => {
-  const [mobileState] = useAtom(mobileStateAtom);
+  const [atlasMobileSidebar, setAtlasMobileSidebar] = useAtom(atlasMobileSidebarAtom);
 
   return (
     <main className="flex min-h-dvh flex-col overflow-hidden">
       <Header />
 
-      {mobileState === "hero" && (
-        <>
-          <AtlasHero />
-          <Newsletter />
-          <Footer />
-        </>
-      )}
+      <Suspense fallback={null}>
+        <div className="flex grow flex-col">
+          <AtlasMap />
 
-      {mobileState === "map" && (
-        <Suspense fallback={null}>
-          <div className="flex grow flex-col">
-            <AtlasMap />
-          </div>
-        </Suspense>
-      )}
-
-      {mobileState === "sidebar" && (
-        <Suspense fallback={null}>
-          <div className="flex h-full w-full">
-            <LayoutGroup>
-              <Suspense fallback={null}>
-                <AtlasNav />
+          <Sheet open={atlasMobileSidebar} onOpenChange={setAtlasMobileSidebar}>
+            <SheetContent side="bottom" className="flex max-h-[80svh] min-h-0 grow flex-col">
+              <div className="flex h-full w-full grow flex-col overflow-hidden">
                 <AtlasSidebar>{children}</AtlasSidebar>
-              </Suspense>
-            </LayoutGroup>
-          </div>
-        </Suspense>
-      )}
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
+      </Suspense>
     </main>
   );
 };

--- a/src/containers/atlas/layout.tsx
+++ b/src/containers/atlas/layout.tsx
@@ -4,37 +4,51 @@ import { PropsWithChildren, Suspense } from "react";
 import { LayoutGroup } from "framer-motion";
 import { useAtom } from "jotai";
 
-import { atlasMobileSidebarAtom } from "@/app/(atlas)/atlas/store";
+import { atlasMobileSidebarAtom, atlasMobileStateAtom } from "@/app/(atlas)/atlas/store";
 
+import { AtlasHero } from "@/containers/atlas/hero";
 import { AtlasMap } from "@/containers/atlas/map";
 import { AtlasNav } from "@/containers/atlas/nav";
 import { AtlasSidebar } from "@/containers/atlas/sidebar";
 import { AtlasTour } from "@/containers/atlas/tour";
+import { Footer } from "@/containers/footer";
 import { Header } from "@/containers/header";
 import { Media } from "@/containers/media";
+import { Newsletter } from "@/containers/newsletter";
 
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 
 export const AtlasLayoutMobile = ({ children }: PropsWithChildren) => {
   const [atlasMobileSidebar, setAtlasMobileSidebar] = useAtom(atlasMobileSidebarAtom);
+  const [atlasMobileState] = useAtom(atlasMobileStateAtom);
 
   return (
     <main className="flex min-h-dvh flex-col overflow-hidden">
       <Header />
 
-      <Suspense fallback={null}>
-        <div className="flex grow flex-col">
-          <AtlasMap />
+      {atlasMobileState === "hero" && (
+        <>
+          <AtlasHero />
+          <Newsletter />
+          <Footer />
+        </>
+      )}
 
-          <Sheet open={atlasMobileSidebar} onOpenChange={setAtlasMobileSidebar}>
-            <SheetContent side="bottom" className="flex max-h-[80svh] min-h-0 grow flex-col">
-              <div className="flex h-full w-full grow flex-col overflow-hidden">
-                <AtlasSidebar>{children}</AtlasSidebar>
-              </div>
-            </SheetContent>
-          </Sheet>
-        </div>
-      </Suspense>
+      {atlasMobileState === "map" && (
+        <Suspense fallback={null}>
+          <div className="flex grow flex-col">
+            <AtlasMap />
+
+            <Sheet open={atlasMobileSidebar} onOpenChange={setAtlasMobileSidebar}>
+              <SheetContent side="bottom" className="flex max-h-[80svh] min-h-0 grow flex-col">
+                <div className="flex h-full w-full grow flex-col overflow-hidden">
+                  <AtlasSidebar>{children}</AtlasSidebar>
+                </div>
+              </SheetContent>
+            </Sheet>
+          </div>
+        </Suspense>
+      )}
     </main>
   );
 };

--- a/src/containers/atlas/map/index.tsx
+++ b/src/containers/atlas/map/index.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 import { getApiLocationsLocationGetQueryOptions } from "@/types/generated/locations";
 
 import {
-  atlasMobileSidebarAtom,
+  // atlasMobileSidebarAtom,
   popupAtom,
   sidebarOpenAtom,
   tmpBboxAtom,
@@ -35,7 +35,7 @@ import { MapShare } from "@/containers/atlas/map/share";
 import { Media } from "@/containers/media";
 
 import Controls from "@/components/map/controls";
-import DataControl from "@/components/map/controls/data";
+// import DataControl from "@/components/map/controls/data";
 import FeedbackControl from "@/components/map/controls/feedback";
 import { MenuControl } from "@/components/map/controls/menu";
 import SettingsControl from "@/components/map/controls/settings";
@@ -58,7 +58,7 @@ export const AtlasMap = () => {
   const [tmpBbox, setTmpBbox] = useAtom(tmpBboxAtom);
   const setPopup = useSetAtom(popupAtom);
   const sidebarOpen = useAtomValue(sidebarOpenAtom);
-  const [atlasMobileSidebar, setAtlasMobileSidebar] = useAtom(atlasMobileSidebarAtom);
+  // const [atlasMobileSidebar, setAtlasMobileSidebar] = useAtom(atlasMobileSidebarAtom);
 
   const mapStyle = BASEMAPS.find((b) => b.value === basemap)?.mapStyle;
 
@@ -148,11 +148,11 @@ export const AtlasMap = () => {
             setLoaded(true);
           }}
         >
-          <Media lessThan="lg">
+          {/* <Media lessThan="lg">
             <Controls className="absolute left-4 right-auto top-4">
               <DataControl onClick={() => setAtlasMobileSidebar(!atlasMobileSidebar)} />
             </Controls>
-          </Media>
+          </Media> */}
           <Controls>
             <Media greaterThanOrEqual="lg">
               <MenuControl />

--- a/src/containers/atlas/map/index.tsx
+++ b/src/containers/atlas/map/index.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { getApiLocationsLocationGetQueryOptions } from "@/types/generated/locations";
 
 import {
+  atlasMobileSidebarAtom,
   popupAtom,
   sidebarOpenAtom,
   tmpBboxAtom,
@@ -34,6 +35,7 @@ import { MapShare } from "@/containers/atlas/map/share";
 import { Media } from "@/containers/media";
 
 import Controls from "@/components/map/controls";
+import DataControl from "@/components/map/controls/data";
 import FeedbackControl from "@/components/map/controls/feedback";
 import { MenuControl } from "@/components/map/controls/menu";
 import SettingsControl from "@/components/map/controls/settings";
@@ -56,6 +58,7 @@ export const AtlasMap = () => {
   const [tmpBbox, setTmpBbox] = useAtom(tmpBboxAtom);
   const setPopup = useSetAtom(popupAtom);
   const sidebarOpen = useAtomValue(sidebarOpenAtom);
+  const [atlasMobileSidebar, setAtlasMobileSidebar] = useAtom(atlasMobileSidebarAtom);
 
   const mapStyle = BASEMAPS.find((b) => b.value === basemap)?.mapStyle;
 
@@ -145,6 +148,11 @@ export const AtlasMap = () => {
             setLoaded(true);
           }}
         >
+          <Media lessThan="lg">
+            <Controls className="absolute left-4 right-auto top-4">
+              <DataControl onClick={() => setAtlasMobileSidebar(!atlasMobileSidebar)} />
+            </Controls>
+          </Media>
           <Controls>
             <Media greaterThanOrEqual="lg">
               <MenuControl />

--- a/src/containers/atlas/sidebar/index.tsx
+++ b/src/containers/atlas/sidebar/index.tsx
@@ -4,11 +4,13 @@ import { PropsWithChildren } from "react";
 
 import { motion } from "framer-motion";
 import { useAtomValue, useSetAtom } from "jotai";
+import { FiX } from "react-icons/fi";
 
-import { navOpenAtom, sidebarOpenAtom } from "@/app/(atlas)/atlas/store";
+import { atlasMobileSidebarAtom, navOpenAtom, sidebarOpenAtom } from "@/app/(atlas)/atlas/store";
+
+import { Media } from "@/containers/media";
 
 import { CollapseSidebarIcon } from "@/components/ui/icons/collapse-sidebar";
-import { ScrollArea } from "@/components/ui/scroll-area";
 
 export const AtlasSidebar = ({ children }: PropsWithChildren) => {
   const navOpen = useAtomValue(navOpenAtom);
@@ -22,7 +24,7 @@ export const AtlasSidebar = ({ children }: PropsWithChildren) => {
         duration: 0.4,
         ease: "easeInOut",
       }}
-      className="pointer-events-none relative z-0 h-full grow lg:w-[450px]"
+      className="pointer-events-none relative z-0 flex h-full w-full flex-col overflow-hidden lg:w-[450px]"
     >
       <motion.div
         initial={"open"}
@@ -35,7 +37,7 @@ export const AtlasSidebar = ({ children }: PropsWithChildren) => {
             x: "-100%",
           },
         }}
-        className="pointer-events-auto flex h-full w-full flex-col border-r border-gray-200 bg-white"
+        className="pointer-events-auto flex h-full w-full flex-col overflow-hidden border-r border-gray-200 bg-white"
         transition={{
           duration: 0.4,
           ease: "easeInOut",
@@ -50,26 +52,38 @@ export const AtlasSidebar = ({ children }: PropsWithChildren) => {
 export const AtlasSidebarSection = ({ children }: PropsWithChildren) => {
   return (
     <section className="flex grow flex-col overflow-hidden">
-      <ScrollArea className="flex grow flex-col">
+      <div className="flex grow flex-col overflow-y-auto overflow-x-hidden">
         <div className="pb-6">{children}</div>
-      </ScrollArea>
+      </div>
     </section>
   );
 };
 
 export const AtlasSidebarHeader = ({ children }: PropsWithChildren) => {
   const setSidebarOpen = useSetAtom(sidebarOpenAtom);
+  const setAtlasMobileSidebarOpen = useSetAtom(atlasMobileSidebarAtom);
 
   return (
     <header className="sticky top-0 z-10 flex justify-between gap-6 bg-gradient-to-b from-white to-white/0 p-6">
       {children}
 
-      <button
-        className="pointer-events-auto z-10 flex h-6 w-6 items-center justify-center text-navy-500 hover:text-navy-700"
-        onClick={() => setSidebarOpen(false)}
-      >
-        <CollapseSidebarIcon className="h-6 w-6" />
-      </button>
+      <Media lessThan="lg">
+        <button
+          className="pointer-events-auto z-10 flex h-6 w-6 items-center justify-center text-navy-500 hover:text-navy-700"
+          onClick={() => setAtlasMobileSidebarOpen(false)}
+        >
+          <FiX className="h-6 w-6" />
+        </button>
+      </Media>
+
+      <Media greaterThanOrEqual="lg">
+        <button
+          className="pointer-events-auto z-10 flex h-6 w-6 items-center justify-center text-navy-500 hover:text-navy-700"
+          onClick={() => setSidebarOpen(false)}
+        >
+          <CollapseSidebarIcon className="h-6 w-6" />
+        </button>
+      </Media>
     </header>
   );
 };

--- a/src/containers/atlas/widgets/location/country_contribution/chart.tsx
+++ b/src/containers/atlas/widgets/location/country_contribution/chart.tsx
@@ -71,7 +71,7 @@ export const CountryContributionNumber = () => {
 
   return (
     <div className="leading-none">
-      <span className="text-4xl font-semibold leading-none">{CURRENT}</span>
+      <span className="text-2xl font-semibold leading-none lg:text-4xl">{CURRENT}</span>
       <span className="text-lg leading-none"> / {TOTAL} </span>
       <span className="text-xs font-medium leading-none">
         {" "}

--- a/src/containers/atlas/widgets/location/current_status/index.tsx
+++ b/src/containers/atlas/widgets/location/current_status/index.tsx
@@ -49,7 +49,7 @@ export const WidgetLocationStatus = () => {
                   <div className="flex items-start justify-between">
                     <div className="space-x-2">
                       <span className="space-x-1">
-                        <span className="text-4xl font-semibold leading-none">
+                        <span className="text-2xl font-semibold leading-none lg:text-4xl">
                           {DATA?.mapped_coverage}
                         </span>
                         <span className="text-lg leading-none">%</span>
@@ -71,15 +71,21 @@ export const WidgetLocationStatus = () => {
                 </div>
                 <div className="grid grid-cols-3 gap-4">
                   <div className="p-4 pb-0">
-                    <div className="text-4xl font-semibold leading-none">{DATA?.realms}</div>
+                    <div className="text-2xl font-semibold leading-none lg:text-4xl">
+                      {DATA?.realms}
+                    </div>
                     <div className="text-sm font-medium leading-none">realms</div>
                   </div>
                   <div className="p-4 pb-0">
-                    <div className="text-4xl font-semibold leading-none">{DATA?.biomes}</div>
+                    <div className="text-2xl font-semibold leading-none lg:text-4xl">
+                      {DATA?.biomes}
+                    </div>
                     <div className="text-sm font-medium leading-none">biomes</div>
                   </div>
                   <div className="p-4 pb-0">
-                    <div className="text-4xl font-semibold leading-none">{DATA?.efgs}</div>
+                    <div className="text-2xl font-semibold leading-none lg:text-4xl">
+                      {DATA?.efgs}
+                    </div>
                     <div className="text-sm font-medium leading-none">
                       ecosystem functional groups
                     </div>

--- a/src/containers/atlas/widgets/location/ecosystem_assesment/index.tsx
+++ b/src/containers/atlas/widgets/location/ecosystem_assesment/index.tsx
@@ -93,7 +93,7 @@ export const WidgetLocationEcosystemAssesment = () => {
                           />
                           <div className="pointer-events-none absolute left-0 top-0 flex h-full w-full flex-col items-center justify-center px-8">
                             <div className="space-x-1">
-                              <span className="text-4xl font-semibold leading-none">
+                              <span className="text-2xl font-semibold leading-none lg:text-4xl">
                                 {formatPercentage(SELECTED ?? 0, {}, false)}
                               </span>
                               <span className="text-lg leading-none">%</span>

--- a/src/containers/atlas/widgets/location/extent_realms/index.tsx
+++ b/src/containers/atlas/widgets/location/extent_realms/index.tsx
@@ -107,7 +107,7 @@ export const WidgetLocationExtentRealms = () => {
                           />
                           <div className="pointer-events-none absolute left-0 top-0 flex h-full w-full flex-col items-center justify-center px-8">
                             <div className="space-x-1">
-                              <span className="text-4xl font-semibold leading-none">
+                              <span className="text-2xl font-semibold leading-none lg:text-4xl">
                                 {formatPercentage(SELECTED?.value ?? 0, {}, false)}
                               </span>
                               <span className="text-lg leading-none">%</span>


### PR DESCRIPTION
This pull request includes several changes to the Atlas project, focusing on refactoring state management, enhancing the user interface, and improving mobile responsiveness. The most important changes include refactoring state atoms, adding new components, and updating UI elements for better consistency and readability.

### State Management Refactoring:
* [`src/app/(atlas)/atlas/store.ts`](diffhunk://#diff-59e02ec778b8ed276e194db9666af847ed02a2f08229e6a6218bf4dee9e7b345L129-R132): Refactored state atoms for mobile state management, replacing `mobileStateAtom` with `atlasMobileStateAtom` and `atlasMobileSidebarAtom`.

### New Components:
* [`src/components/map/controls/data/index.tsx`](diffhunk://#diff-d0da94cd635fb6510452e138e8865e01b73358557db5f8904a88204b1d7646b9R1-R63): Added a new `DataControl` component with tooltip functionality.
* [`src/components/ui/sheet.tsx`](diffhunk://#diff-319e19004d72883ad55ee0b5035771b79f614157b68d255d86a036a1dc78876eR1-R126): Introduced a new `Sheet` component with various subcomponents (`SheetContent`, `SheetHeader`, `SheetFooter`, etc.) for better layout management.

### UI Enhancements:
* [`src/containers/atlas/hero.tsx`](diffhunk://#diff-14b4011e122ef7731152c49d87872cdf6c0fc60b86d156bbf92db8696a1ab76aL5-R30): Updated the hero section to use `H3` instead of `H2` and modified button texts for better clarity. [[1]](diffhunk://#diff-14b4011e122ef7731152c49d87872cdf6c0fc60b86d156bbf92db8696a1ab76aL5-R30) [[2]](diffhunk://#diff-14b4011e122ef7731152c49d87872cdf6c0fc60b86d156bbf92db8696a1ab76aL38-R56)
* [`src/containers/atlas/widgets/location/*`](diffhunk://#diff-4294ff73309fa52180c8d7121dcffd07b93cf1d58c5cc3318343edac43e7b140L74-R74): Adjusted font sizes for better readability across different screen sizes. [[1]](diffhunk://#diff-4294ff73309fa52180c8d7121dcffd07b93cf1d58c5cc3318343edac43e7b140L74-R74) [[2]](diffhunk://#diff-3b146d0450ef2045c78776a4cac4ccd9d8122d20585f9fb8ad90b805d2bc473aL52-R52) [[3]](diffhunk://#diff-3b146d0450ef2045c78776a4cac4ccd9d8122d20585f9fb8ad90b805d2bc473aL74-R88) [[4]](diffhunk://#diff-90f559ac9e838005dbd22b2e0e26902864cc1d2da6fe908a0bf5d12daf52e62cL96-R96)

### Mobile Responsiveness:
* [`src/containers/atlas/layout.tsx`](diffhunk://#diff-ff8c240e1faade68fbf99b7e73faac31cd12e59d6ab1c6ae4bbcfe9a30701f0aL7-R7): Integrated the new `Sheet` component for mobile sidebar management and updated state handling to use the new atoms. [[1]](diffhunk://#diff-ff8c240e1faade68fbf99b7e73faac31cd12e59d6ab1c6ae4bbcfe9a30701f0aL7-R7) [[2]](diffhunk://#diff-ff8c240e1faade68fbf99b7e73faac31cd12e59d6ab1c6ae4bbcfe9a30701f0aR19-R48)
* [`src/containers/atlas/sidebar/index.tsx`](diffhunk://#diff-d905796a3d1caa5ac21c6b5a57e2eec2fc23252f3d4662b80cdc129f5cd5ebc0R7-L11): Enhanced the sidebar to be more responsive and included a close button for mobile views. [[1]](diffhunk://#diff-d905796a3d1caa5ac21c6b5a57e2eec2fc23252f3d4662b80cdc129f5cd5ebc0R7-L11) [[2]](diffhunk://#diff-d905796a3d1caa5ac21c6b5a57e2eec2fc23252f3d4662b80cdc129f5cd5ebc0L25-R27) [[3]](diffhunk://#diff-d905796a3d1caa5ac21c6b5a57e2eec2fc23252f3d4662b80cdc129f5cd5ebc0L38-R40) [[4]](diffhunk://#diff-d905796a3d1caa5ac21c6b5a57e2eec2fc23252f3d4662b80cdc129f5cd5ebc0L53-R86)

### Code Cleanup:
* [`src/containers/atlas/map/index.tsx`](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R19): Removed unused imports and commented out code related to the old state management and controls. [[1]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R19) [[2]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R38) [[3]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R61) [[4]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R151-R155)