### PR TITLE
Tools and Legend mobile

### DIFF
--- a/src/app/(atlas)/atlas/store.ts
+++ b/src/app/(atlas)/atlas/store.ts
@@ -128,5 +128,6 @@ export const tourAtom = atom<boolean>();
 // mobile
 export const atlasMobileStateAtom = atom<"hero" | "map">("hero");
 export const atlasMobileSidebarAtom = atom<boolean>(false);
+export const atlasMobileLegendAtom = atom<boolean>(false);
 
 // export const atlasPopupAtom = atom<boolean>(false);

--- a/src/components/map/controls/legend/index.tsx
+++ b/src/components/map/controls/legend/index.tsx
@@ -3,25 +3,25 @@
 import { FC, HTMLAttributes, PropsWithChildren } from "react";
 
 import { TooltipPortal } from "@radix-ui/react-tooltip";
+import { FiLayers } from "react-icons/fi";
 
 import { cn } from "@/lib/utils";
 
-import { ExpandIcon } from "@/components/ui/icons/expand";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import { CONTROL_BUTTON_STYLES } from "../constants";
 
-interface DataControlProps {
+interface LegendControlProps {
   id?: string;
   className?: HTMLAttributes<HTMLDivElement>["className"];
   onClick?: () => void;
 }
 
-export const DataControl: FC<PropsWithChildren<DataControlProps>> = ({
+export const LegendControl: FC<PropsWithChildren<LegendControlProps>> = ({
   id,
   className,
   onClick,
-}: PropsWithChildren<DataControlProps>) => {
+}: PropsWithChildren<LegendControlProps>) => {
   return (
     <div className={cn("flex flex-col space-y-0.5", className)}>
       {/* <Popover> */}
@@ -34,31 +34,24 @@ export const DataControl: FC<PropsWithChildren<DataControlProps>> = ({
               [CONTROL_BUTTON_STYLES.default]: true,
               [CONTROL_BUTTON_STYLES.hover]: true,
               [CONTROL_BUTTON_STYLES.active]: true,
-              "bg-pistachio-200 text-navy-700 hover:bg-pistachio-300": true,
             })}
             aria-label="Map settings"
             type="button"
             onClick={onClick}
           >
-            <ExpandIcon className="relative h-full w-full rotate-90" />
+            <FiLayers className="h-6 w-6" />
           </button>
         </TooltipTrigger>
         {/* </PopoverTrigger> */}
 
         <TooltipPortal>
           <TooltipContent side="left" align="center">
-            <div className="text-xxs">Data</div>
+            <div className="text-xxs">Legend</div>
           </TooltipContent>
         </TooltipPortal>
-
-        {/* <PopoverContent side="left" align="start">
-          {children}
-          <PopoverArrow className="fill-white" width={10} height={5} />
-        </PopoverContent> */}
       </Tooltip>
-      {/* </Popover> */}
     </div>
   );
 };
 
-export default DataControl;
+export default LegendControl;

--- a/src/containers/atlas/layout.tsx
+++ b/src/containers/atlas/layout.tsx
@@ -16,7 +16,7 @@ import { Header } from "@/containers/header";
 import { Media } from "@/containers/media";
 import { Newsletter } from "@/containers/newsletter";
 
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 
 export const AtlasLayoutMobile = ({ children }: PropsWithChildren) => {
   const [atlasMobileSidebar, setAtlasMobileSidebar] = useAtom(atlasMobileSidebarAtom);
@@ -41,6 +41,8 @@ export const AtlasLayoutMobile = ({ children }: PropsWithChildren) => {
 
             <Sheet open={atlasMobileSidebar} onOpenChange={setAtlasMobileSidebar}>
               <SheetContent side="bottom" className="flex max-h-[80svh] min-h-0 grow flex-col">
+                <SheetTitle hidden>Tools</SheetTitle>
+                <SheetDescription hidden>Explore the map tools</SheetDescription>
                 <div className="flex h-full w-full grow flex-col overflow-hidden">
                   <AtlasSidebar>{children}</AtlasSidebar>
                 </div>

--- a/src/containers/atlas/map/index.tsx
+++ b/src/containers/atlas/map/index.tsx
@@ -7,6 +7,7 @@ import Map, { LngLatBoundsLike, useMap } from "react-map-gl";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { MapMouseEvent } from "mapbox-gl";
+import { FiChevronUp } from "react-icons/fi";
 import { useDebounce, usePreviousDifferent } from "rooks";
 
 import { env } from "@/env.mjs";
@@ -16,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { getApiLocationsLocationGetQueryOptions } from "@/types/generated/locations";
 
 import {
+  atlasMobileLegendAtom,
   atlasMobileSidebarAtom,
   popupAtom,
   sidebarOpenAtom,
@@ -28,18 +30,21 @@ import {
 
 import { BASEMAPS } from "@/containers/atlas/map/basemaps";
 import { LayerManager } from "@/containers/atlas/map/layer-manager";
-import MapLegend from "@/containers/atlas/map/legend";
+import { MapLegendDesktop, MapLegendMobile } from "@/containers/atlas/map/legend";
 import { AtlasPopup } from "@/containers/atlas/map/popup";
 import { MapSettings } from "@/containers/atlas/map/settings";
 import { MapShare } from "@/containers/atlas/map/share";
+import { Media } from "@/containers/media";
 
 import Controls from "@/components/map/controls";
-import DataControl from "@/components/map/controls/data";
 import FeedbackControl from "@/components/map/controls/feedback";
+import { LegendControl } from "@/components/map/controls/legend";
 import { MenuControl } from "@/components/map/controls/menu";
 import SettingsControl from "@/components/map/controls/settings";
 import ShareControl from "@/components/map/controls/share";
 import ZoomControl from "@/components/map/controls/zoom";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 
 export interface AtlasMapProps {
   mobile?: boolean;
@@ -62,6 +67,7 @@ export const AtlasMap = ({ mobile }: AtlasMapProps) => {
   const setPopup = useSetAtom(popupAtom);
   const sidebarOpen = useAtomValue(sidebarOpenAtom);
   const [atlasMobileSidebar, setAtlasMobileSidebar] = useAtom(atlasMobileSidebarAtom);
+  const [atlasMobileLegend, setAtlasMobileLegend] = useAtom(atlasMobileLegendAtom);
 
   const mapStyle = BASEMAPS.find((b) => b.value === basemap)?.mapStyle;
 
@@ -152,12 +158,6 @@ export const AtlasMap = ({ mobile }: AtlasMapProps) => {
             setLoaded(true);
           }}
         >
-          {mobile && (
-            <Controls className="absolute left-4 right-auto top-4">
-              <DataControl onClick={() => setAtlasMobileSidebar(!atlasMobileSidebar)} />
-            </Controls>
-          )}
-
           <Controls>
             {!mobile && <MenuControl />}
             {!mobile && <ZoomControl />}
@@ -169,6 +169,8 @@ export const AtlasMap = ({ mobile }: AtlasMapProps) => {
               <MapShare />
             </ShareControl>
             <FeedbackControl id="tour-atlas-feedback" />
+
+            {mobile && <LegendControl onClick={() => setAtlasMobileLegend(true)} />}
           </Controls>
 
           {loaded && <LayerManager />}
@@ -176,7 +178,32 @@ export const AtlasMap = ({ mobile }: AtlasMapProps) => {
         </Map>
       </div>
 
-      <MapLegend />
+      <Media lessThan="lg">
+        <>
+          <div className="absolute bottom-10 right-4 z-10 w-full max-w-[calc(100%_-_theme(space.8))] shadow-lg">
+            <Button
+              variant="default"
+              className="flex w-full items-center justify-between"
+              onClick={() => setAtlasMobileSidebar(!atlasMobileSidebar)}
+            >
+              <span className="uppercase">Tools</span>
+              <FiChevronUp className="h-5 w-5" />
+            </Button>
+          </div>
+
+          <Sheet open={atlasMobileLegend} onOpenChange={setAtlasMobileLegend}>
+            <SheetContent side="bottom" className="flex max-h-[80svh] min-h-0 grow flex-col">
+              <SheetTitle hidden>Legend</SheetTitle>
+              <SheetDescription hidden>Explore the map legend</SheetDescription>
+              <MapLegendMobile />
+            </SheetContent>
+          </Sheet>
+        </>
+      </Media>
+
+      <Media greaterThanOrEqual="lg">
+        <MapLegendDesktop />
+      </Media>
     </div>
   );
 };

--- a/src/containers/atlas/map/legend/index.tsx
+++ b/src/containers/atlas/map/legend/index.tsx
@@ -9,8 +9,35 @@ import { MapLegendItem } from "@/containers/atlas/map/legend/item";
 import Legend from "@/components/map/legend";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 
-const MapLegend = ({ className = "" }) => {
+export const MapLegendDesktop = () => {
   const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="absolute bottom-10 right-4 z-10 w-full max-w-[calc(100%_-_theme(space.8))] shadow-lg lg:right-6 lg:max-w-sm">
+      <Collapsible className="rounded-lg bg-white" onOpenChange={setExpanded}>
+        <CollapsibleTrigger className="flex w-full items-center justify-between p-4">
+          <span className="text-xs font-bold uppercase">Legend</span>
+          <span className="text-xs font-medium">{expanded ? "Collapse" : "Expand"}</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <MapLegend />
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+};
+
+export const MapLegendMobile = () => {
+  return (
+    <div className="flex grow flex-col overflow-hidden">
+      <span className="p-4 text-sm font-bold uppercase leading-none">Legend</span>
+
+      <MapLegend />
+    </div>
+  );
+};
+
+const MapLegend = ({ className = "" }) => {
   const [layers, setLayers] = useSyncLayers();
   const [layersSettings, setLayersSettings] = useSyncLayersSettings();
 
@@ -82,29 +109,19 @@ const MapLegend = ({ className = "" }) => {
   }, [LAYERS, layersSettings, handleChangeOpacity, handleChangeVisibility]);
 
   return (
-    <div className="absolute bottom-10 right-4 z-10 w-full max-w-[calc(100%_-_theme(space.8))] shadow-lg lg:right-6 lg:max-w-sm">
-      <Collapsible className="rounded-lg bg-white" onOpenChange={setExpanded}>
-        <CollapsibleTrigger className="flex w-full items-center justify-between p-4">
-          <span className="text-xs font-bold uppercase">Layers</span>
-          <span className="text-xs font-medium">{expanded ? "Collapse all" : "Expand all"}</span>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <Legend
-            className={cn(
-              "max-h-[calc(100vh_-_theme(space.48)_-_theme(space.6)_-_theme(space.60))]",
-              className,
-            )}
-            sortable={{
-              enabled: true,
-              handle: true,
-            }}
-            onChangeOrder={handleChangeOrder}
-          >
-            {ITEMS}
-          </Legend>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
+    <Legend
+      className={cn(
+        "lg:max-h-[calc(100vh_-_theme(space.48)_-_theme(space.6)_-_theme(space.60))]",
+        className,
+      )}
+      sortable={{
+        enabled: true,
+        handle: true,
+      }}
+      onChangeOrder={handleChangeOrder}
+    >
+      {ITEMS}
+    </Legend>
   );
 };
 


### PR DESCRIPTION
This pull request introduces several changes focused on improving the map legend functionality and enhancing the mobile layout of the atlas. The most important changes include the addition of new atoms, renaming and refactoring of components, and updates to the layout and controls for better user experience on mobile devices.

### Map Legend Enhancements:

* Renamed `DataControl` component to `LegendControl` and updated its icon and text to reflect the legend functionality in `src/components/map/controls/legend/index.tsx` [[1]](diffhunk://#diff-c3b2fec630348484515b76cd06c2c623506f9e2c032a4fd6fc4869a6d1803ef1R6-R24) [[2]](diffhunk://#diff-c3b2fec630348484515b76cd06c2c623506f9e2c032a4fd6fc4869a6d1803ef1L37-R57).
* Split `MapLegend` into `MapLegendDesktop` and `MapLegendMobile` for better handling of different screen sizes in `src/containers/atlas/map/legend/index.tsx` [[1]](diffhunk://#diff-acbf0e45f58086525b99957e6ba681228ae18763a2256020dacc2a6fb552e81fL12-R40) [[2]](diffhunk://#diff-acbf0e45f58086525b99957e6ba681228ae18763a2256020dacc2a6fb552e81fL85-R114) [[3]](diffhunk://#diff-acbf0e45f58086525b99957e6ba681228ae18763a2256020dacc2a6fb552e81fL105-L107).

### Mobile Layout Improvements:

* Added new atoms `atlasMobileLegendAtom` to manage the state of the legend on mobile devices in `src/app/(atlas)/atlas/store.ts`.
* Updated `AtlasLayoutMobile` to include hidden titles and descriptions for better accessibility in `src/containers/atlas/layout.tsx` [[1]](diffhunk://#diff-ff8c240e1faade68fbf99b7e73faac31cd12e59d6ab1c6ae4bbcfe9a30701f0aL19-R19) [[2]](diffhunk://#diff-ff8c240e1faade68fbf99b7e73faac31cd12e59d6ab1c6ae4bbcfe9a30701f0aR44-R45).
* Modified `AtlasMap` component to include the new `LegendControl` and handle the mobile legend state in `src/containers/atlas/map/index.tsx` [[1]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R10) [[2]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R20) [[3]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9L31-R47) [[4]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R70) [[5]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9L155-L160) [[6]](diffhunk://#diff-82a3399c2394fcdf51863ba15f82b82797b70ece3d49dccc0b239953759fefe9R172-R206).