### PR TITLE
Popup mobile

### DIFF
--- a/src/containers/atlas/map/popup/index.tsx
+++ b/src/containers/atlas/map/popup/index.tsx
@@ -10,8 +10,10 @@ import { FiX } from "react-icons/fi";
 import { popupAtom, useSyncLayers, useSyncLayersSettings } from "@/app/(atlas)/atlas/store";
 
 import { POPUPS } from "@/containers/atlas/map/popup/content";
+import { Media } from "@/containers/media";
 
 import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 
 export const AtlasPopup = () => {
   const [layers] = useSyncLayers();
@@ -22,46 +24,72 @@ export const AtlasPopup = () => {
   if (!popup) return null;
 
   return (
-    <Popup
-      latitude={popup.lat}
-      longitude={popup.lng}
-      closeOnClick={false}
-      maxWidth={"none"}
-      className="font-sans"
-      style={{
-        padding: 0,
-      }}
-      closeButton={false}
-      onClose={() => setPopup(null)}
-    >
-      <div className="pointer-events-none absolute left-0 top-0 h-4 w-full rounded-t-lg bg-gradient-to-b from-lightblue-50" />
-      <div
-        className="max-h-[45vh] w-[380px] space-y-2.5 overflow-y-auto overflow-x-hidden rounded-lg bg-lightblue-50 p-3 pr-6 text-navy-500 shadow-[0_20px_15px_rgba(0,0,0,0.1)]"
-        style={{
-          transform: "translateZ(0px)",
-          backfaceVisibility: "hidden",
-        }}
-      >
-        {layers
-          .filter((layer) => {
-            const layerSettings = layersSettings?.[layer] ?? {};
-            const visibility = layerSettings?.visibility ?? true;
-            return visibility && !!POPUPS[layer as keyof typeof POPUPS];
-          })
-          .map((layer) => {
-            const PopupComponent = POPUPS[layer as keyof typeof POPUPS];
-            return <PopupComponent key={layer} />;
-          })}
-      </div>
-      <Button
-        size="icon"
-        variant="ghost"
-        className="absolute right-0 top-0"
-        onClick={() => setPopup(null)}
-      >
-        <FiX className="h-5 w-5" />
-      </Button>
-      <div className="pointer-events-none absolute bottom-0 left-0 h-4 w-full rounded-b-lg bg-gradient-to-t from-lightblue-50" />
-    </Popup>
+    <>
+      <Media greaterThanOrEqual="lg">
+        <Popup
+          latitude={popup.lat}
+          longitude={popup.lng}
+          closeOnClick={false}
+          maxWidth={"none"}
+          className="font-sans"
+          style={{
+            padding: 0,
+          }}
+          closeButton={false}
+          onClose={() => setPopup(null)}
+        >
+          <div className="pointer-events-none absolute left-0 top-0 h-4 w-full rounded-t-lg bg-gradient-to-b from-lightblue-50" />
+          <div
+            className="max-h-[45vh] w-[380px] space-y-2.5 overflow-y-auto overflow-x-hidden rounded-lg bg-lightblue-50 p-3 pr-6 text-navy-500 shadow-[0_20px_15px_rgba(0,0,0,0.1)]"
+            style={{
+              transform: "translateZ(0px)",
+              backfaceVisibility: "hidden",
+            }}
+          >
+            {layers
+              .filter((layer) => {
+                const layerSettings = layersSettings?.[layer] ?? {};
+                const visibility = layerSettings?.visibility ?? true;
+                return visibility && !!POPUPS[layer as keyof typeof POPUPS];
+              })
+              .map((layer) => {
+                const PopupComponent = POPUPS[layer as keyof typeof POPUPS];
+                return <PopupComponent key={layer} />;
+              })}
+          </div>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="absolute right-0 top-0"
+            onClick={() => setPopup(null)}
+          >
+            <FiX className="h-5 w-5" />
+          </Button>
+          <div className="pointer-events-none absolute bottom-0 left-0 h-4 w-full rounded-b-lg bg-gradient-to-t from-lightblue-50" />
+        </Popup>
+      </Media>
+
+      <Media lessThan="lg">
+        <Sheet open={!!popup} onOpenChange={(open) => !open && setPopup(null)}>
+          <SheetContent side="bottom" className="flex max-h-[80svh] min-h-0 grow flex-col">
+            <SheetTitle hidden>Popup</SheetTitle>
+            <SheetDescription hidden>Explore the map popup</SheetDescription>
+
+            <div className="flex h-full w-full grow flex-col overflow-hidden p-4">
+              {layers
+                .filter((layer) => {
+                  const layerSettings = layersSettings?.[layer] ?? {};
+                  const visibility = layerSettings?.visibility ?? true;
+                  return visibility && !!POPUPS[layer as keyof typeof POPUPS];
+                })
+                .map((layer) => {
+                  const PopupComponent = POPUPS[layer as keyof typeof POPUPS];
+                  return <PopupComponent key={layer} />;
+                })}
+            </div>
+          </SheetContent>
+        </Sheet>
+      </Media>
+    </>
   );
 };

--- a/src/containers/atlas/sidebar/index.tsx
+++ b/src/containers/atlas/sidebar/index.tsx
@@ -131,7 +131,7 @@ export const AtlasSidebarTitle = ({ children }: PropsWithChildren) => {
 
   return (
     <>
-      <div className="relative w-full">
+      <div className="relative w-full" tabIndex={1}>
         <Media lessThan="lg">
           <select
             className="absolute left-0 top-0 h-full w-full opacity-0"


### PR DESCRIPTION
This pull request introduces enhancements to the `AtlasPopup` component, including responsive design improvements and accessibility updates. The most important changes include the addition of the `Media` component for responsive rendering, the integration of the `Sheet` component for mobile views, and an accessibility improvement in the `AtlasSidebarTitle` component.

### Enhancements to `AtlasPopup`:

* [`src/containers/atlas/map/popup/index.tsx`](diffhunk://#diff-971434d0a0a9280de0aaf2a1a0fd73bf47ae896cb207316351c4f00496e6df7fR27-R28): Added the `Media` component to conditionally render the `Popup` component for larger screens and the `Sheet` component for smaller screens. This ensures a responsive design that adapts to different screen sizes. [[1]](diffhunk://#diff-971434d0a0a9280de0aaf2a1a0fd73bf47ae896cb207316351c4f00496e6df7fR27-R28) [[2]](diffhunk://#diff-971434d0a0a9280de0aaf2a1a0fd73bf47ae896cb207316351c4f00496e6df7fR70-R93)
* [`src/containers/atlas/map/popup/index.tsx`](diffhunk://#diff-971434d0a0a9280de0aaf2a1a0fd73bf47ae896cb207316351c4f00496e6df7fR13-R16): Imported the `Media`, `Sheet`, `SheetContent`, `SheetDescription`, and `SheetTitle` components to support the new responsive layout.

### Accessibility improvement:

* [`src/containers/atlas/sidebar/index.tsx`](diffhunk://#diff-d905796a3d1caa5ac21c6b5a57e2eec2fc23252f3d4662b80cdc129f5cd5ebc0L134-R134): Added `tabIndex={1}` to the `div` element in `AtlasSidebarTitle` to improve keyboard navigation accessibility.